### PR TITLE
Ensure Rack::UTF8 Sanitizer is first middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Or install it yourself as:
 For Rails, add this to your `application.rb`:
 
 ``` ruby
-config.middleware.insert_before "Rack::Runtime", Rack::UTF8Sanitizer
+config.middleware.insert 0, Rack::UTF8Sanitizer
 ```
 
 For Rack apps, add this to `config.ru`:


### PR DESCRIPTION
If you set config.force_ssl=true in the rails app, it inserts the ActionDispatch::SSL middleware before Rack::Runtime. ActionDispatch::SSL also suffers from the utf8 issue. If we do config.middleware.insert 0, this ensures Rack::UTF8Sanitizer is at the top of the stack.
