### PR TITLE
Sanitize request body for all HTTP verbs

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -28,15 +28,8 @@ module Rack
       application/x-www-form-urlencoded
     )
 
-    # MRI-optimization
-    POST = 'POST'
-    PUT  = 'PUT'
-
     def sanitize(env)
-      request_method = env['REQUEST_METHOD']
-      if request_method == POST || request_method == PUT
-        sanitize_rack_input(env)
-      end
+      sanitize_rack_input(env)
       env.each do |key, value|
         if URI_FIELDS.include?(key)
           env[key] = transfer_frozen(value,

--- a/rack-utf8_sanitizer.gemspec
+++ b/rack-utf8_sanitizer.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "bacon"
   gem.add_development_dependency "bacon-colored_output"
+  gem.add_development_dependency "rake"
 end

--- a/test/test_utf8_sanitizer.rb
+++ b/test/test_utf8_sanitizer.rb
@@ -186,6 +186,17 @@ describe Rack::UTF8Sanitizer do
       end
     end
 
+    it "sanitizes StringIO rack.input on GET" do
+      input = "foo=bla&quux=bar"
+      @rack_input = StringIO.new input
+
+      sanitize_form_data(request_env.merge("REQUEST_METHOD" => "GET")) do |sanitized_input|
+        sanitized_input.encoding.should == Encoding::UTF_8
+        sanitized_input.should.be.valid_encoding
+        sanitized_input.should == input
+      end
+    end
+
     it "sanitizes StringIO rack.input with bad encoding" do
       input =  "foo=bla&quux=bar\xED"
       @rack_input = StringIO.new input


### PR DESCRIPTION
The HTTP spec allows a GET body, and Rails violates the intent of the
spec by parsing that body (and I wouldn't be surprised if other
frameworks do as well). Unfortunately this means that a poorly behaved
client (looking at you, EasuoSpider) can submit bad UTF-8 in a GET and
cause upstream problems.

This fixes the issue by sanitizing `rack.input` - the request body - for
all request methods.

Closes #14.
