### PR TITLE
Protect against Symbol keys in the rack `env`

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -36,7 +36,7 @@ module Rack
         if URI_FIELDS.include?(key)
           env[key] = transfer_frozen(value,
               sanitize_uri_encoded_string(value))
-        elsif key.start_with?("HTTP_")
+        elsif key.to_s.start_with?("HTTP_")
           # Just sanitize the headers and leave them in UTF-8. There is
           # no reason to have UTF-8 in headers, but if it's valid, let it be.
           env[key] = transfer_frozen(value,

--- a/test/test_utf8_sanitizer.rb
+++ b/test/test_utf8_sanitizer.rb
@@ -152,6 +152,22 @@ describe Rack::UTF8Sanitizer do
     end
   end
 
+  describe "with symbols in the env" do
+    before do
+      @uri_input = "http://bar/foo%E0\xe0".force_encoding('UTF-8')
+    end
+
+    it "sanitizes REQUEST_PATH with invalid UTF-8 URI input" do
+      env  = @app.({ :requested_at => "2014-07-22",
+                     "REQUEST_PATH" => @uri_input })
+
+      result = env["REQUEST_PATH"]
+
+      result.encoding.should == Encoding::US_ASCII
+      result.should.be.valid_encoding
+    end
+  end
+
   describe "with form data" do
     def request_env
       @plain_input = "foo bar лол".force_encoding('UTF-8')


### PR DESCRIPTION
Sometimes the rack `env` can get a key that's a symbol. This was causing
the `starts_with?` method to fail. This is simply fixed by added a `to_s`
call to the key before calling `starts_with?`

Test for the behavior by adding a dummy symbol key in the env
