### PR TITLE
Sanitize encoded form data, too

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -94,8 +94,8 @@ module Rack
       input = io.read
       sanitized_input = sanitize_string(input)
       if uri_encoded
-        sanitized_input = sanitize_uri_encoded_string(sanitized_input)
-        sanitized_input = sanitized_input.force_encoding(Encoding::UTF_8)
+        sanitized_input = sanitize_uri_encoded_string(sanitized_input).
+          force_encoding(Encoding::UTF_8)
       end
       sanitized_input = transfer_frozen(input, sanitized_input)
       SanitizedRackInput.new(io, StringIO.new(sanitized_input))

--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -32,6 +32,10 @@ module Rack
       text/javascript
     )
 
+    URI_ENCODED_CONTENT_TYPES = %w(
+      application/x-www-form-urlencoded
+    )
+
     def sanitize(env)
       sanitize_rack_input(env)
       env.each do |key, value|
@@ -57,7 +61,8 @@ module Rack
       content_type &&= content_type.split(/\s*[;,]\s*/, 2).first
       content_type &&= content_type.downcase
       return unless SANITIZABLE_CONTENT_TYPES.any? {|type| content_type == type }
-      env['rack.input'] &&= sanitize_io(env['rack.input'])
+      uri_encoded = URI_ENCODED_CONTENT_TYPES.any? {|type| content_type == type}
+      env['rack.input'] &&= sanitize_io(env['rack.input'], uri_encoded)
     end
 
     # Modeled after Rack::RewindableInput
@@ -85,11 +90,15 @@ module Rack
       end
     end
 
-    def sanitize_io(io)
+    def sanitize_io(io, uri_encoded = false)
       input = io.read
-      sanitized_io = transfer_frozen(input,
-                      sanitize_string(input))
-      SanitizedRackInput.new(io, StringIO.new(sanitized_io))
+      sanitized_input = sanitize_string(input)
+      if uri_encoded
+        sanitized_input = sanitize_uri_encoded_string(sanitized_input)
+        sanitized_input = sanitized_input.force_encoding(Encoding::UTF_8)
+      end
+      sanitized_input = transfer_frozen(input, sanitized_input)
+      SanitizedRackInput.new(io, StringIO.new(sanitized_input))
     end
 
     # URI.encode/decode expect the input to be in ASCII-8BIT.

--- a/test/test_utf8_sanitizer.rb
+++ b/test/test_utf8_sanitizer.rb
@@ -229,6 +229,7 @@ describe Rack::UTF8Sanitizer do
       @rack_input = StringIO.new input
 
       sanitize_form_data do |sanitized_input|
+        # URI.decode_www_form does some encoding magic
         sanitized_input.split("&").each do |pair|
           pair.split("=", 2).each do |component|
             decoded = URI.decode_www_form_component(component)

--- a/test/test_utf8_sanitizer.rb
+++ b/test/test_utf8_sanitizer.rb
@@ -224,6 +224,21 @@ describe Rack::UTF8Sanitizer do
       end
     end
 
+    it "sanitizes StringIO rack.input with form encoded bad encoding" do
+      input = "foo=bla&foo=baz&quux%ED=bar%ED"
+      @rack_input = StringIO.new input
+
+      sanitize_form_data do |sanitized_input|
+        sanitized_input.split("&").each do |pair|
+          pair.split("=", 2).each do |component|
+            decoded = URI.decode_www_form_component(component)
+            decoded.should.be.valid_encoding
+          end
+        end
+        sanitized_input.should != input
+      end
+    end
+
     it "sanitizes non-StringIO rack.input" do
       require 'rack/rewindable_input'
       input = "foo=bla&quux=bar"


### PR DESCRIPTION
We're using the sanitizer in production but receive errors when users submit form data to us which is invalidly encoded within the form encoded data in the request input stream. The test case included might be clearer than my explanation. :-)