### PR TITLE
Strip UTF-8 Byte Order Mark from the request body

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   # 2.1, not 2.1.0 until fixed https://github.com/travis-ci/travis-ci/issues/2220

--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -108,7 +108,7 @@ module Rack
 
     def sanitize_io(io, uri_encoded = false)
       input = io.read
-      sanitized_input = sanitize_string(input)
+      sanitized_input = sanitize_string(strip_byte_order_mark(input))
       if uri_encoded
         sanitized_input = sanitize_uri_encoded_string(sanitized_input).
           force_encoding(Encoding::UTF_8)
@@ -200,6 +200,14 @@ module Rack
       else
         to
       end
+    end
+
+    UTF8_BOM = "\xef\xbb\xbf".force_encoding(Encoding::BINARY).freeze
+    UTF8_BOM_SIZE = UTF8_BOM.bytesize
+
+    def strip_byte_order_mark(input)
+      return input unless input.start_with?(UTF8_BOM)
+      input.byteslice(UTF8_BOM_SIZE..-1)
     end
   end
 end

--- a/rack-utf8_sanitizer.gemspec
+++ b/rack-utf8_sanitizer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 1.9'
+  gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_dependency             "rack", '~> 1.0'
 

--- a/test/test_utf8_sanitizer.rb
+++ b/test/test_utf8_sanitizer.rb
@@ -227,6 +227,17 @@ describe Rack::UTF8Sanitizer do
       end
     end
 
+    it "strip UTF-8 BOM from StringIO rack.input" do
+      input = %(\xef\xbb\xbf{"Hello": "World"})
+      @rack_input = StringIO.new input
+
+      sanitize_form_data(request_env.merge("CONTENT_TYPE" => "application/json")) do |sanitized_input|
+        sanitized_input.encoding.should == Encoding::UTF_8
+        sanitized_input.should.be.valid_encoding
+        sanitized_input.should == '{"Hello": "World"}'
+      end
+    end
+
     it "sanitizes StringIO rack.input with form encoded bad encoding" do
       input = "foo=bla&foo=baz&quux%ED=bar%ED"
       @rack_input = StringIO.new input


### PR DESCRIPTION
Context: 

Some weird and outdated clients are sending JSON payloads prefixed with BOMs (Byte Order Mark https://en.wikipedia.org/wiki/Byte_order_mark). The client in question: http://www.indyproject.org/index.en.aspx

This can be reproduced with curl:

```bash
curl -X POST -H 'Content-Type: application/json' http://localhost:3000/ -d"'\xEF\xBB\xBF{}"
```

So most JSON parsers then blow up.

Regards.
