### PR TITLE
add options to #initialize to allow configurable sanitizable content …

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ For fields with "raw data", the algorithm is applied once and the (UTF-8 encoded
 
 For fields with "percent-encoded data", the algorithm is applied twice to catch both invalid characters appearing as-is and invalid characters appearing in the percent encoding. The percent encoded, ASCII-8BIT encoded result is left in the environment.
 
+### Sanitizable content types
+
+The default content types to be sanitized are 'text/plain', 'application/x-www-form-urlencoded', 'application/json', 'text/javascript'. You may wish to modify this, for example if your app accepts specific or custom media types in the CONTENT_TYPE header. If you want to change the sanitizable content types, you can pass options when using Rack::UTF8Sanitizer. 
+
+To add sanitizable content types to the list of defaults, pass the `additional_content_types` options when using Rack::UTF8Sanitizer, e.g.
+
+    config.middleware.insert 0, Rack::UTF8Sanitizer, additional_content_types: ['application/vnd.api+json']
+
+To explicitly set sanitizable content types and override the defaults, use the `sanitizable_content_types` option:
+
+    config.middleware.insert 0, Rack::UTF8Sanitizer, sanitizable_content_types: ['application/vnd.api+json']
+
 ## Contributing
 
 1. Fork it

--- a/README.md
+++ b/README.md
@@ -62,3 +62,5 @@ To explicitly set sanitizable content types and override the defaults, use the `
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
+
+To run the tests, run `rake spec` in the project directory.

--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -27,18 +27,18 @@ module Rack
         HTTP_REFERER
         ORIGINAL_FULLPATH
         ORIGINAL_SCRIPT_NAME
-    )
+    ).map(&:freeze).freeze
 
     SANITIZABLE_CONTENT_TYPES = %w(
       text/plain
       application/x-www-form-urlencoded
       application/json
       text/javascript
-    )
+    ).map(&:freeze).freeze
 
     URI_ENCODED_CONTENT_TYPES = %w(
       application/x-www-form-urlencoded
-    )
+    ).map(&:freeze).freeze
 
     def sanitize(env)
       sanitize_rack_input(env)

--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -12,7 +12,7 @@ module Rack
     def initialize(app, options={})
       @app = app
       @sanitizable_content_types = options[:sanitizable_content_types]
-      @sanitizable_content_types ||= SANITIZABLE_CONTENT_TYPES.concat(options[:additional_content_types] || [])
+      @sanitizable_content_types ||= SANITIZABLE_CONTENT_TYPES + (options[:additional_content_types] || [])
     end
 
     def call(env)

--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -7,8 +7,12 @@ module Rack
   class UTF8Sanitizer
     StringIO = ::StringIO
 
-    def initialize(app)
+    # options[:sanitizable_content_types] Array
+    # options[:additional_content_types] Array
+    def initialize(app, options={})
       @app = app
+      @sanitizable_content_types = options[:sanitizable_content_types]
+      @sanitizable_content_types ||= SANITIZABLE_CONTENT_TYPES.concat(options[:additional_content_types])
     end
 
     def call(env)
@@ -60,7 +64,7 @@ module Rack
       content_type   = env['CONTENT_TYPE']
       content_type &&= content_type.split(/\s*[;,]\s*/, 2).first
       content_type &&= content_type.downcase
-      return unless SANITIZABLE_CONTENT_TYPES.any? {|type| content_type == type }
+      return unless @sanitizable_content_types.any? {|type| content_type == type }
       uri_encoded = URI_ENCODED_CONTENT_TYPES.any? {|type| content_type == type}
 
       if env["rack.input"]

--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -12,7 +12,7 @@ module Rack
     def initialize(app, options={})
       @app = app
       @sanitizable_content_types = options[:sanitizable_content_types]
-      @sanitizable_content_types ||= SANITIZABLE_CONTENT_TYPES.concat(options[:additional_content_types])
+      @sanitizable_content_types ||= SANITIZABLE_CONTENT_TYPES.concat(options[:additional_content_types] || [])
     end
 
     def call(env)


### PR DESCRIPTION
…types

I have apps that support media types like 'application/vnd.api+json' in the Content-Type header and I would like to sanitize that data. I added a simple options hash to the initialize method so that users can configure additional content types to be sanitized (or replace the sanitized content types altogether if they want to). Thoughts?