### PR TITLE
Make HTTP_ a constants to avoid creating the string every loop

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -40,13 +40,15 @@ module Rack
       application/x-www-form-urlencoded
     ).map(&:freeze).freeze
 
+    HTTP_ = 'HTTP_'.freeze
+
     def sanitize(env)
       sanitize_rack_input(env)
       env.each do |key, value|
         if URI_FIELDS.include?(key)
           env[key] = transfer_frozen(value,
               sanitize_uri_encoded_string(value))
-        elsif key.to_s.start_with?("HTTP_")
+        elsif key.to_s.start_with?(HTTP_)
           # Just sanitize the headers and leave them in UTF-8. There is
           # no reason to have UTF-8 in headers, but if it's valid, let it be.
           env[key] = transfer_frozen(value,


### PR DESCRIPTION
I noticed we were getting a lot of strings allocated from utf8-sanitizer during requests, so I tooke the opportunity to reduce the string allocation.

See [my gist with memory_profiler output for the test run before and after](https://gist.github.com/martinemde/db2e08db793621d4d1da/revisions). The gist has a few revisions which show the difference between the two runs as a diff instead of trying to compare outputs.

```
-Total allocated: 143837 bytes (1955 objects) # before
+Total allocated: 132357 bytes (1668 objects) # after
```