### PR TITLE
Use more performant %char decoding `.hex.chr`

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -156,7 +156,7 @@ module Rack
     # enough for our task.
     def unescape_unreserved(input)
       input.gsub(/%([a-f\d]{2})/i) do |encoded|
-        decoded = [$1.hex].pack('C')
+        decoded = $1.hex.chr
 
         if decoded =~ UNRESERVED_OR_UTF8
           decoded


### PR DESCRIPTION
See the [benchmark gist](https://gist.github.com/martinemde/b5878885b7a8ac93f4cf) for details.

```
             hex.chr:  5071323.8 i/s
        array pack C:  1797414.4 i/s - 2.82x slower
      array pack 'C':  1565692.9 i/s - 3.24x slower
```