### PR TITLE
Add sanitize host name

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -27,6 +27,7 @@ module Rack
         HTTP_REFERER
         ORIGINAL_FULLPATH
         ORIGINAL_SCRIPT_NAME
+        SERVER_NAME
     ).map(&:freeze).freeze
 
     SANITIZABLE_CONTENT_TYPES = %w(

--- a/test/test_utf8_sanitizer.rb
+++ b/test/test_utf8_sanitizer.rb
@@ -28,6 +28,17 @@ describe Rack::UTF8Sanitizer do
     end
   end
 
+  describe "with invalid host input" do
+    it "sanitizes host entity (SERVER_NAME)" do
+      host   = "host\xD0".force_encoding('UTF-8')
+      env    = @app.({ "SERVER_NAME" => host })
+      result = env["SERVER_NAME"]
+
+      result.encoding.should == Encoding::US_ASCII
+      result.should.be.valid_encoding
+    end
+  end
+
   describe "with invalid UTF-8 input" do
     before do
       @plain_input = "foo\xe0".force_encoding('UTF-8')


### PR DESCRIPTION
Hello, I had many issues with Encoding::UndefinedConversionError with text `"\xD0" from ASCII-8BIT to UTF-8`. It comes from host name (because in my rails app I need to serve page depends on domain name).

It should fix that kind of problems.