### PR TITLE
Sanitize `nil` in `sanitize_uri_encoded_string`

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -168,7 +168,7 @@ module Rack
     #
     # The result is guaranteed to be UTF-8-safe.
     def sanitize_uri_encoded_string(input)
-      input ||= '' if input.nil?
+      return input if input.nil?
       decoded_value = decode_string(input)
       reencode_string(decoded_value)
     end

--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -168,6 +168,7 @@ module Rack
     #
     # The result is guaranteed to be UTF-8-safe.
     def sanitize_uri_encoded_string(input)
+      input ||= '' if input.nil?
       decoded_value = decode_string(input)
       reencode_string(decoded_value)
     end


### PR DESCRIPTION
In our setup, we have run to the following bug: in `env` argument given to sanitize contains `nil` for certain keys. Calling `sanitize_uri_encoded_string` results in calling `force_encoding` on that nil.

If the argument is `nil`, let's don't touch it and return it straight away.