### PR TITLE
Add sanitation of cookie header

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -160,6 +160,11 @@ module Rack
       SanitizedRackInput.new(io, StringIO.new(sanitized_input))
     end
 
+    # Cookies need to be split and then sanitized as url encoded strings
+    # since the cookie string itself is not url encoded (separated by `;`),
+    # and the normal method of `sanitize_uri_encoded_string` would break
+    # later cookie parsing in the case that a cookie value contained an
+    # encoded `;`.
     def sanitize_cookies(env)
       return unless env['HTTP_COOKIE']
 


### PR DESCRIPTION
Cookies can be url encoded. Since they are not included in the list of URI_FIELDS, url encoded invalid UTF8 in cookies are not sanitized. However, just adding HTTP_COOKIE to URI_FIELDS won't work, because in order to safely replace invalid UTF8, we need to first split the cookie header. The regular expression used here is the same used by rack when parsing the cookie.

@whitequark, please let me know you thoughts about this addition.