### PR TITLE
Resolve Ruby warnings about `URI.escape`

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -231,7 +231,7 @@ module Rack
     # Performs the reverse function of `unescape_unreserved`. Unlike
     # the previous function, we can reuse the logic in URI#encode
     def escape_unreserved(input)
-      URI.encode(input, UNSAFE)
+      URI::DEFAULT_PARSER.escape(input, UNSAFE)
     end
 
     def sanitize_string(input)


### PR DESCRIPTION
I see that `URI::DEFAULT_PARSER.escape`, which includes `URI::Parser.new`,
which refers to `URI::RFC2396_Parser`, are not deprecated (obsolete).

I hope they will not be removed.

Resolve #51