### PR TITLE
Fix CI: drop old Ruby versions and add new ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1
-  - 2.2
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
+  - 2.7
   - jruby
 
 before_install:


### PR DESCRIPTION
There is `gem install bundler`, and Bundler requires Ruby `>= 2.3`.