### PR TITLE
"cleaner" option with null-byte removal strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,26 @@ end
 config.middleware.insert 0, Rack::UTF8Sanitizer, strategy: replace_string
 ```
 
+### Cleaners
+
+There are two built in cleaners for custom sanitization. The default cleaner is `:noop`, which does nothing (for backwards-compatibility). The second built in cleaner is `:null_byte` which will remove null-bytes, to address security concerns.
+
+An object that responds to `#call` and accepts the sanitized string as an argument can also be passed as a `:cleaner`. This is how you can define custom cleaners.
+
+```ruby
+config.middleware.insert 0, Rack::UTF8Sanitizer, cleaner: :null_byte
+```
+
+```ruby
+replace_string = lambda do |input|
+  Rails.logger.warn('Replacing foo with bar in any input string')
+
+  input.gsub('foo', 'bar')
+end
+
+config.middleware.insert 0, Rack::UTF8Sanitizer, cleaner: replace_string
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -194,9 +194,10 @@ module Rack
     end
 
     def decode_string(input)
-      unescape_unreserved(
-        sanitize_string(input).
-          force_encoding(Encoding::ASCII_8BIT))
+      sanitize_string(
+        unescape_unreserved(
+          sanitize_string(input).
+            force_encoding(Encoding::ASCII_8BIT)))
     end
 
     # This regexp matches all 'unreserved' characters from RFC3986 (2.3),

--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -201,7 +201,7 @@ module Rack
 
     # This regexp matches all 'unreserved' characters from RFC3986 (2.3),
     # plus all multibyte UTF-8 characters.
-    UNRESERVED_OR_UTF8 = /[A-Za-z0-9\-._~\x80-\xFF]/
+    UNRESERVED_OR_UTF8 = /[A-Za-z0-9\-._~\x80-\xFF\x00]/
 
     # RFC3986, 2.2 states that the characters from 'reserved' group must be
     # protected during normalization (which is what UTF8Sanitizer does).

--- a/test/test_utf8_sanitizer.rb
+++ b/test/test_utf8_sanitizer.rb
@@ -494,6 +494,71 @@ describe Rack::UTF8Sanitizer do
     end
   end
 
+  describe "with custom cleaner" do
+    def request_env
+      @plain_input = "foo \x00 bar".force_encoding('UTF-8')
+      {
+          "REQUEST_METHOD" => "POST",
+          "CONTENT_TYPE" => "application/json",
+          "HTTP_USER_AGENT" => @plain_input,
+          "rack.input" => @rack_input,
+      }
+    end
+
+    def sanitize_data(request_env = request_env())
+      @uri_input = "http://bar/foo+%00+bar".force_encoding('UTF-8')
+      @response_env = @app.(request_env)
+      sanitized_input = @response_env['rack.input'].read
+
+      yield sanitized_input if block_given?
+    end
+
+    it "calls a default cleaner (noop)" do
+      @app = Rack::UTF8Sanitizer.new(-> env { env })
+
+      input = "foo=bla&quux=bar\x00"
+      @rack_input = StringIO.new input
+
+      env = request_env
+      sanitize_data(env) do |sanitized_input|
+        sanitized_input.encoding.should == Encoding::UTF_8
+        sanitized_input.should.be.valid_encoding
+        sanitized_input.should == input
+      end
+    end
+
+    it "calls the null_byte cleaner" do
+      @app = Rack::UTF8Sanitizer.new(-> env { env }, cleaner: :null_byte)
+
+      input = "foo=bla&quux=bar\x00"
+      @rack_input = StringIO.new input
+
+      env = request_env
+      sanitize_data(env) do |sanitized_input|
+        sanitized_input.encoding.should == Encoding::UTF_8
+        sanitized_input.should.be.valid_encoding
+        sanitized_input.should != input
+        sanitized_input.should == "foo=bla&quux=bar"
+      end
+    end
+
+    it "accepts a proc as a cleaner" do
+      truncate = -> input { input[0] }
+
+      @app = Rack::UTF8Sanitizer.new(-> env { env }, cleaner: truncate)
+
+      input = "foo=bla&quux=bar\x00"
+      @rack_input = StringIO.new input
+
+      env = request_env
+      sanitize_data(env) do |sanitized_input|
+        sanitized_input.encoding.should == Encoding::UTF_8
+        sanitized_input.should.be.valid_encoding
+        sanitized_input.should == 'f' 
+      end
+    end
+  end
+
   describe "with custom strategy" do
     def request_env
       @plain_input = "foo bar лол".force_encoding('UTF-8')


### PR DESCRIPTION
The goal is to prevent null-byte attacks. This adds the `cleaner` option, which mimics the `strategy` option, allowing for custom sanitization. This comes with the `noop` (default, backwards-compatible) and `null_byte` cleaners.
