### PR TITLE
Handle EOFError

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -6,6 +6,7 @@ require 'stringio'
 module Rack
   class UTF8Sanitizer
     StringIO = ::StringIO
+    BAD_REQUEST = [400, { "Content-Type" => "text/plain" }, ["Bad Request"]]
 
     # options[:sanitizable_content_types] Array
     # options[:additional_content_types] Array
@@ -19,7 +20,12 @@ module Rack
     end
 
     def call(env)
-      @app.call(sanitize(env))
+      begin
+        env = sanitize(env)
+      rescue EOFError
+        return BAD_REQUEST
+      end
+      @app.call(env)
     end
 
     DEFAULT_STRATEGIES = {

--- a/test/test_utf8_sanitizer.rb
+++ b/test/test_utf8_sanitizer.rb
@@ -205,6 +205,18 @@ describe Rack::UTF8Sanitizer do
       @response_env['rack.input'].close
     end
 
+    class BrokenIO < StringIO
+      def read
+        raise EOFError
+      end
+    end
+
+    it "returns HTTP 400 on EOF" do
+      @rack_input = BrokenIO.new
+      @response_env = @app.(request_env)
+      @response_env.should == [400, {"Content-Type"=>"text/plain"}, ["Bad Request"]]
+    end
+
     it "sanitizes StringIO rack.input" do
       input = "foo=bla&quux=bar"
       @rack_input = StringIO.new input
@@ -549,7 +561,7 @@ describe Rack::UTF8Sanitizer do
       sanitize_data(env) do |sanitized_input|
         sanitized_input.encoding.should == Encoding::UTF_8
         sanitized_input.should.be.valid_encoding
-        sanitized_input.should == 'replace' 
+        sanitized_input.should == 'replace'
       end
     end
   end


### PR DESCRIPTION
We've seen errors in production when on a POST request, reading `rack.input` raises with `EOFError`. This might be to do with clients closing aborting the TCP session too early when their POST data is not fully sent.

This leads to `EOFError` getting raised in this gem, because the sanitizer middleware is the first one in the middleware stack to access `rack.input`.

I'd like to make this gem handle `EOFError` and serve `HTTP 400 Bad Request` when it happens.

@whitequark 
cc @rafaelfranca @thomasbarton 