### PR TITLE
Optimize sanitizing www-form-urlencoded input

### DIFF
--- a/test/bench_utf8_sanitizer.rb
+++ b/test/bench_utf8_sanitizer.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'minitest/benchmark'
+
+require_relative '../lib/rack/utf8_sanitizer'
+
+class RackUTF8SanitizerBenchmark < Minitest::Benchmark
+  def self.bench_range
+    bench_exp(10, 1_000_000, 10)
+  end
+
+  def hex
+    rand(255).to_s(16)
+  end
+
+  def data(size, encode_ratio: 1.0)
+    buffer = String.new
+    size.times.reduce(buffer) { |str, _|
+      encoded = rand + encode_ratio >= 1.0
+      str << (encoded ? "%#{hex}" : '___')
+    }
+  end
+
+  def setup
+    @data = data(10_000_000, encode_ratio: 0.2)
+  end
+
+  def bench_urlencoded_input
+    app = Rack::UTF8Sanitizer.new(->(env) { env })
+
+    request_env = {
+      'REQUEST_METHOD' => 'POST',
+      'CONTENT_TYPE' => 'application/x-www-form-urlencoded'
+    }
+
+    assert_performance_linear 0.99 do |n|
+      20.times do
+        offset = rand((@data.size / 3) - n)
+        data = @data.slice(offset, n)
+        app.call(request_env.merge('rack.input' => StringIO.new(data)))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Using gsub with block syntax is slow. This implementation uses lookup tables to
cache the mapping of encoded/decoded characters since these are known subsets /
ranges, and handle replacement in a way that doesn't have any overhead for
yielding.

Benchmarks for random payloads containing 20% urlencoded characters show a
considerable improvement:

Before:
0.000900	 0.000565	 0.003071	 0.033079	 0.305175	 3.015223

After:
0.000836	 0.000488	 0.001445	 0.011248	 0.110888	 1.107596

Tested data payload sizes are 10b, 100b, 1kb, 10kb, 100kb, 1mb.