### PR TITLE
Drop unused "executables" directive from gemspec

### DIFF
--- a/rack-utf8_sanitizer.gemspec
+++ b/rack-utf8_sanitizer.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |gem|
   gem.homepage      = "http://github.com/whitequark/rack-utf8_sanitizer"
 
   gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 


### PR DESCRIPTION
This gem exposes no executables.