### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", ruby-head, jruby-9.2, jruby-9.3, jruby-head]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true # 'bundle install' and cache gems
+        ruby-version: ${{ matrix.ruby }}
+    - name: Run tests
+      run: bundle exec rake

--- a/test/test_utf8_sanitizer.rb
+++ b/test/test_utf8_sanitizer.rb
@@ -1,6 +1,7 @@
 # encoding:ascii-8bit
 
 require 'bacon/colored_output'
+require 'cgi'
 require 'rack/utf8_sanitizer'
 
 describe Rack::UTF8Sanitizer do
@@ -118,6 +119,7 @@ describe Rack::UTF8Sanitizer do
   describe "with valid, not percent-encoded UTF-8 URI input" do
     before do
       @uri_input   = "http://bar/foo+bar+лол".force_encoding('UTF-8')
+      @encoded     = "http://bar/foo+bar+#{CGI.escape("лол")}"
     end
 
     it "does not change URI-like entity (REQUEST_PATH)" do
@@ -126,7 +128,7 @@ describe Rack::UTF8Sanitizer do
 
       result.encoding.should == Encoding::US_ASCII
       result.should.be.valid_encoding
-      result.should == URI.encode(@uri_input)
+      result.should == @encoded
     end
   end
 


### PR DESCRIPTION
Migrates CI to GitHub Actions as Travis CI.org is no longer active.

Also update specs to avoid use of `URI.escape` - this method is deprecated in `2.7` and removed in `3.0`.