### PR TITLE
Add '#' to safe character list in URI fields

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -232,7 +232,7 @@ module Rack
     # `unescape_unreserved` invocation.
     #
     # See also URI::REGEXP::PATTERN::{UNRESERVED,RESERVED}.
-    RFC3986_GEN_DELIMS = Regexp.escape(%(:/?[]@))
+    RFC3986_GEN_DELIMS = Regexp.escape(%(:/?#[]@))
     RFC3986_SUB_DELIMS = Regexp.escape(%(!$&'()*+,;=))
     UNSAFE             = /[^#{RFC3986_GEN_DELIMS}#{RFC3986_SUB_DELIMS}a-zA-Z\d\-._~%]/x
 

--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -232,7 +232,9 @@ module Rack
     # `unescape_unreserved` invocation.
     #
     # See also URI::REGEXP::PATTERN::{UNRESERVED,RESERVED}.
-    UNSAFE           = /[^\-_.!~*'()a-zA-Z\d;\/?:@&=+$,\[\]%]/
+    RFC3986_GEN_DELIMS = Regexp.escape(%(:/?[]@))
+    RFC3986_SUB_DELIMS = Regexp.escape(%(!$&'()*+,;=))
+    UNSAFE             = /[^#{RFC3986_GEN_DELIMS}#{RFC3986_SUB_DELIMS}a-zA-Z\d\-._~%]/x
 
     # Performs the reverse function of `unescape_unreserved`. Unlike
     # the previous function, we can reuse the logic in URI#encode

--- a/test/test_utf8_sanitizer.rb
+++ b/test/test_utf8_sanitizer.rb
@@ -76,6 +76,15 @@ describe Rack::UTF8Sanitizer do
     behaves_like :does_sanitize_uri
   end
 
+  describe "with valid URI input containing a URI fragment" do
+    it "does not percent-encode the fragment" do
+      env = @app.({ 'HTTP_REFERER' => 'http://bar/foo/#qux' })
+      result = env['HTTP_REFERER']
+
+      result.should == 'http://bar/foo/#qux'
+    end
+  end
+
   shared :identity_plain do
     it "does not change plaintext entity (HTTP_USER_AGENT)" do
       env    = @app.({ "HTTP_USER_AGENT" => @plain_input })


### PR DESCRIPTION
When escaping URI fields we avoid escaping reserved characters per the [RFC3986 2.2 spec](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2). However, we're missing the '#' character from the RFC's gen-delims character class, which this PR fixes:

    reserved    = gen-delims / sub-delims
    gen-delims  = ":" / "/" / "?" / "#" / "[" / "]" / "@"
    sub-delims  = "!" / "$" / "&" / "'" / "(" / ")"
                  / "*" / "+" / "," / ";" / "="

### Feedback

Any and all feedback is extremely welcome, but in particular:

* I can see that '#' isn't in `URI::REGEXP::PATTERN::RESERVED` to which the code comment refers, but [that code in ruby](https://github.com/ruby/ruby/blob/cb02324c4e5c7aae0add0a5c4e5adbf637d9acb0/lib/uri/rfc2396_parser.rb#L41-L45) refers to [RFC2732](https://datatracker.ietf.org/doc/html/rfc2732), which was obsoleted by 3986, so I think it's also out of date. Is that the reason '#' was originally omitted here, or is there something else I've missed?
* I've added a first commit to break up the regexp before actually changing it, but I'm very happy to drop this if it's not preferred.

p.s. Many thanks for an extremely useful gem that has saved us so many pointless error alerts.