### PR TITLE
Fix null byte sanitisation

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -45,12 +45,13 @@ module Rack
         input
       end,
       exception: lambda do |input, sanitize_null_bytes: false|
-        if sanitize_null_bytes && input =~ NULL_BYTE_REGEX
-          raise NullByteInString
-        end
         input.
           force_encoding(Encoding::ASCII_8BIT).
           encode!(Encoding::UTF_8)
+        if sanitize_null_bytes && input =~ NULL_BYTE_REGEX
+          raise NullByteInString
+        end
+        input
       end
     }.freeze
 

--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -34,14 +34,15 @@ module Rack
 
     DEFAULT_STRATEGIES = {
       replace: lambda do |input, sanitize_null_bytes: false|
-        if sanitize_null_bytes
-          input = input.gsub(NULL_BYTE_REGEX, "")
-        end
         input.
           force_encoding(Encoding::ASCII_8BIT).
           encode!(Encoding::UTF_8,
                   invalid: :replace,
                   undef:   :replace)
+        if sanitize_null_bytes
+          input = input.gsub(NULL_BYTE_REGEX, "")
+        end
+        input
       end,
       exception: lambda do |input, sanitize_null_bytes: false|
         if sanitize_null_bytes && input =~ NULL_BYTE_REGEX

--- a/test/test_utf8_sanitizer.rb
+++ b/test/test_utf8_sanitizer.rb
@@ -351,25 +351,25 @@ describe Rack::UTF8Sanitizer do
 
     it "optionally sanitizes null bytes with the replace strategy" do
       @app = Rack::UTF8Sanitizer.new(-> env { env }, sanitize_null_bytes: true)
-      input =  "foo=bla&quux=bar\x00"
+      input = "foo=bla\xED&quux=bar\x00"
       @rack_input = StringIO.new input
 
       sanitize_form_data do |sanitized_input|
         sanitized_input.encoding.should == Encoding::UTF_8
         sanitized_input.should.be.valid_encoding
-        sanitized_input.should == "foo=bla&quux=bar"
+        sanitized_input.should == "foo=bla%EF%BF%BD&quux=bar"
       end
     end
 
     it "optionally sanitizes encoded null bytes with the replace strategy" do
       @app = Rack::UTF8Sanitizer.new(-> env { env }, sanitize_null_bytes: true)
-      input =  "foo=bla&quux=bar%00"
+      input = "foo=bla%ED&quux=bar%00"
       @rack_input = StringIO.new input
 
       sanitize_form_data do |sanitized_input|
         sanitized_input.encoding.should == Encoding::UTF_8
         sanitized_input.should.be.valid_encoding
-        sanitized_input.should == "foo=bla&quux=bar"
+        sanitized_input.should == "foo=bla%EF%BF%BD&quux=bar"
       end
     end
 

--- a/test/test_utf8_sanitizer.rb
+++ b/test/test_utf8_sanitizer.rb
@@ -392,6 +392,16 @@ describe Rack::UTF8Sanitizer do
         sanitize_form_data
       end
     end
+
+    it "gives precedence to encoding errors with the exception strategy and null byte sanitisation" do
+      @app = Rack::UTF8Sanitizer.new(-> env { env }, sanitize_null_bytes: true, strategy: :exception)
+      input = "foo=bla\x00&quux=bar\xED"
+      @rack_input = StringIO.new input
+
+      should.raise(EncodingError) do
+        sanitize_form_data
+      end
+    end
   end
 
   describe "with custom content-type" do


### PR DESCRIPTION
Trying to sanitise input containing both invalid `UTF-8` characters and null bytes will currently raise `ArgumentError: invalid byte sequence in UTF-8` when the newly introduced `sanitize_null_bytes` option is set to `true`. The reason for that is that the optional null byte sanitisation happens before forcing `UTF-8` encoding. This fixes that by making sure character sanitisation is performed first in both the default strategies