### PR TITLE
Avoid 2nd degree polynomial regexp for sanitizing content type

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -118,9 +118,13 @@ module Rack
       # https://github.com/rack/rack/blob/master/lib/rack/request.rb#L42
       # Logic borrowed from Rack::Request#media_type,#media_type_params,#content_charset
       # Ignoring charset in content type.
-      content_type   = env['CONTENT_TYPE']
-      content_type &&= content_type.split(/\s*[;,]\s*/, 2).first
-      content_type &&= content_type.downcase
+      if content_type = env['CONTENT_TYPE']
+        content_type = content_type.split(/[;,]/, 2).first
+        if content_type
+          content_type.strip!
+          content_type.downcase!
+        end
+      end
       return unless @sanitizable_content_types.any? {|type| content_type == type }
       uri_encoded = URI_ENCODED_CONTENT_TYPES.any? {|type| content_type == type}
 


### PR DESCRIPTION
This can lead to ReDos on Ruby 3.1 and older.