### PR TITLE
Use Regexp#match? over String#=~ when testing for null bytes

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -49,7 +49,7 @@ module Rack
         input.
           force_encoding(Encoding::ASCII_8BIT).
           encode!(Encoding::UTF_8)
-        if sanitize_null_bytes && input =~ NULL_BYTE_REGEX
+        if sanitize_null_bytes && NULL_BYTE_REGEX.match?(input)
           raise NullByteInString
         end
         input


### PR DESCRIPTION
https://github.com/fastruby/fast-ruby#regexp-vs-regexpmatch-vs-regexpmatch-vs-stringmatch-vs-string-vs-stringmatch-code-

This change updates the null byte checking in the included `exception` strategy to scan for null bytes with `Regexp#match?`. It appears this will be 2.5x faster when parsing the data, which might be helpful given the overhead of running this on every request.