### PR TITLE
Add the frozen_string_literal header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", ruby-head, jruby-9.2, jruby-9.3, jruby-head]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", ruby-head, jruby-9.2, jruby-9.3, jruby-head]
 
     steps:
     - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rack-utf8_sanitizer.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 
 task :default => :spec

--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+# frozen_string_literal: true
 
 require 'uri'
 require 'stringio'
@@ -64,20 +65,20 @@ module Rack
         ORIGINAL_FULLPATH
         ORIGINAL_SCRIPT_NAME
         SERVER_NAME
-    ).map(&:freeze).freeze
+    ).freeze
 
     SANITIZABLE_CONTENT_TYPES = %w(
       text/plain
       application/x-www-form-urlencoded
       application/json
       text/javascript
-    ).map(&:freeze).freeze
+    ).freeze
 
     URI_ENCODED_CONTENT_TYPES = %w(
       application/x-www-form-urlencoded
-    ).map(&:freeze).freeze
+    ).freeze
 
-    HTTP_ = 'HTTP_'.freeze
+    HTTP_ = 'HTTP_'
 
     def sanitize(env)
       sanitize_rack_input(env)
@@ -280,7 +281,7 @@ module Rack
       end
     end
 
-    UTF8_BOM = "\xef\xbb\xbf".force_encoding(Encoding::BINARY).freeze
+    UTF8_BOM = "\xef\xbb\xbf".dup.force_encoding(Encoding::BINARY).freeze
     UTF8_BOM_SIZE = UTF8_BOM.bytesize
 
     def strip_byte_order_mark(input)

--- a/rack-utf8_sanitizer.gemspec
+++ b/rack-utf8_sanitizer.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: true
 
 Gem::Specification.new do |gem|
   gem.name          = "rack-utf8_sanitizer"
@@ -6,8 +7,8 @@ Gem::Specification.new do |gem|
   gem.authors       = ["whitequark"]
   gem.license       = "MIT"
   gem.email         = ["whitequark@whitequark.org"]
-  gem.description   = %{Rack::UTF8Sanitizer is a Rack middleware which cleans up } <<
-                      %{invalid UTF8 characters in request URI and headers.}
+  gem.description   = "Rack::UTF8Sanitizer is a Rack middleware which cleans up " \
+                      "invalid UTF8 characters in request URI and headers."
   gem.summary       = gem.description
   gem.homepage      = "http://github.com/whitequark/rack-utf8_sanitizer"
 


### PR DESCRIPTION
I think after Ruby 3.4 is released[^1], more people will start expecting libraries to be functional with e.g. the `--enable-frozen-string-literal` option enabled.

This PR adds the `frozen_string_literal` header to all files, fixes failing tests, and removes now unnecessary freezing of strings.

[^1]:https://github.com/ruby/ruby/commit/12be40ae6be78ac41e8e3f3c313cc6f63e7fa6c4