### PR TITLE
Remove deprecation warming by switching from URI::DEFAULT_PARSER to U…

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -256,7 +256,7 @@ module Rack
     # Performs the reverse function of `unescape_unreserved`. Unlike
     # the previous function, we can reuse the logic in URI#encode
     def escape_unreserved(input)
-      URI::DEFAULT_PARSER.escape(input, UNSAFE)
+      URI::RFC2396_PARSER.escape(input, UNSAFE)
     end
 
     def sanitize_string(input)


### PR DESCRIPTION
Change:

```
URI::DEFAULT_PARSER.escape(input, UNSAFE)
```

To:

```
URI::RFC2396_PARSER.escape(input, UNSAFE)
```