### PR TITLE
Fix URI::RFC2396_PARSER issue with older Rubies

### DIFF
--- a/lib/rack/utf8_sanitizer.rb
+++ b/lib/rack/utf8_sanitizer.rb
@@ -256,7 +256,11 @@ module Rack
     # Performs the reverse function of `unescape_unreserved`. Unlike
     # the previous function, we can reuse the logic in URI#encode
     def escape_unreserved(input)
-      URI::RFC2396_PARSER.escape(input, UNSAFE)
+      if Object.const_defined?("URI::RFC2396_PARSER")
+        URI::RFC2396_PARSER.escape(input, UNSAFE)
+      else
+        URI::DEFAULT_PARSER.escape(input, UNSAFE)
+      end
     end
 
     def sanitize_string(input)


### PR DESCRIPTION
Switching to URI::RFC2396_PARSER in 028fd338d8fc667c resulted in problems with older versions of Ruby where URI::RFC2396_PARSER is not defined. Although URI::RFC2396_PARSER was added and backported to the vendored uri library in older versions of Ruby, we check for URI::RFC2396_PARSER's presence such that the warnings are avoided when using a newer non-vendored version of the gem. See https://github.com/ruby/uri/issues/118.