### PR TITLE
CI: add Ruby 3.4, support JRuby 9.2 (using ubuntu-22.04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,16 @@ on: [push, pull_request]
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", ruby-head, jruby-9.3, jruby-head]
         include:
           - ruby: jruby-9.2
-            runs-on: ubuntu-20.04
+            os: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", ruby-head, jruby-9.3, jruby-head]
+        include:
+          - os: ubuntu-22.04
+            ruby: jruby-9.2
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", ruby-head, jruby-9.2, jruby-9.3, jruby-head]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", ruby-head, jruby-9.3, jruby-head]
+        include:
+          - ruby: jruby-9.2
+            runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", ruby-head, jruby-9.3, jruby-head]
-        include:
-          - ruby: jruby-9.2
-            os: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", ruby-head, jruby-9.2, jruby-9.3, jruby-head]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", ruby-head, jruby-9.2, jruby-9.3, jruby-head]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This PR extends the build matrix with the latest generally-available Ruby version.

Turns out that JRuby 9.2 no longer is supported by ubuntu-latest. The Ubuntu 20.04 I tried adding was dropped in April. But, 22.04 supports it. Fixes #96.